### PR TITLE
Fix live playback URL to include credentials

### DIFF
--- a/qml/pages/StreamPlayerPage.qml
+++ b/qml/pages/StreamPlayerPage.qml
@@ -22,7 +22,7 @@ Page {
 
         MediaPlayer {
             id: videoPlayer
-            source: TVHClient.hostname + ":" + TVHClient.port + url
+            source: TVHClient.baseUrl() + url
             autoPlay: true
 
             onError: console.log(errorString)
@@ -72,5 +72,4 @@ Page {
 
     onStatusChanged: keepAlive.preventBlanking = (status === PageStatus.Active)
 }
-
 

--- a/src/tvhclient.cpp
+++ b/src/tvhclient.cpp
@@ -86,7 +86,7 @@ TVHClient::~TVHClient()
 
 const QString TVHClient::baseUrl() const
 {
-    return QStringLiteral("%1:%2").arg(m_hostname, QString::number(m_port));
+    return m_baseUrl;
 }
 
 ChannelsModel *TVHClient::channelsModel()


### PR DESCRIPTION
## Summary
- expose the credential-aware `m_baseUrl` to QML by having `TVHClient::baseUrl()` return it directly
- make the stream player reuse `TVHClient.baseUrl()` when building the media source, so authenticated servers are addressed with `user:pass@host`

## Testing
- Tested with tvheadend server with authentication
- **NOT** tested with tvheadend server without authentication, but should work

Fixes #4 