### PR TITLE
Fix PasswordField to include the password

### DIFF
--- a/qml/pages/SettingsAuthenticationPage.qml
+++ b/qml/pages/SettingsAuthenticationPage.qml
@@ -50,6 +50,7 @@ Page {
 
                 label: qsTr("Password")
 
+                text: TVHClient.password
                 readOnly: TVHClient.password.length > 0
             }
         }


### PR DESCRIPTION
Earlier password was not shown in the SettingsAuthenticationPage